### PR TITLE
Allow other python default location

### DIFF
--- a/bin/find_contaminations.py
+++ b/bin/find_contaminations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 import sys, os, time, logging, glob
 from pathlib import Path
 from multiprocessing import Pool

--- a/bin/prepare_data.py
+++ b/bin/prepare_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 import sys, os, logging, glob
 from pathlib import Path
 from multiprocessing import Pool, Lock

--- a/bin/utils/plot.py
+++ b/bin/utils/plot.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2.7
 import os, sys, glob
 from pathlib import Path
 from tqdm import tqdm

--- a/test/simulation/get_statistics.py
+++ b/test/simulation/get_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 
 import glob, os, re
 from pathlib import Path

--- a/test/test_data_manger.py
+++ b/test/test_data_manger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 import unittest
 
 ROOT_PATH = str(Path(os.path.dirname(os.path.realpath(__file__))).parent)

--- a/test/test_types_manager.py
+++ b/test/test_types_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 import sys, os, unittest
 from pathlib import Path
 


### PR DESCRIPTION
Allow to run WinstonCleaner on systems where ̀python2.7` is not in `/usr/bin/`